### PR TITLE
chore: drop unnecessary `placeholder` for `InputDate`

### DIFF
--- a/apps/demo/src/app/home/home.component.html
+++ b/apps/demo/src/app/home/home.component.html
@@ -19,10 +19,6 @@
             (mousedown.capture.stop)="(0)"
         >
             Choose date
-            <input
-                placeholder="dd.mm.yyyy"
-                tuiTextfield
-            />
         </tui-input-date>
         <tui-calendar
             class="calendar"


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

- [X] Bugfix
- [ ] Feature
- [ ] Refactoring
- [ ] Build or CI related changes
- [ ] Tests related changes
- [ ] Documentation content changes

## What is the current behaviour?
1. Open https://taiga-family.github.io/preview-landing-components
2. Focus `InputDate`
3. Type `99`

https://github.com/taiga-family/preview-landing-components/assets/35179038/a9d20154-aa1d-4f25-bfbf-222f7baebf90

